### PR TITLE
Fixing default user creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       - ./app:/app
     command: >
       sh -c "python manage.py wait_for_db &&
-             python manage.py create_user &&
              python manage.py migrate &&
+             python manage.py create_user &&
              python manage.py runserver 0.0.0.0:8000"
     environment:
       - DB_HOST=db


### PR DESCRIPTION
Moving the create_user command after the migrations command so that the tables are ready